### PR TITLE
Update rk3368-thermal.dtsi

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3368-thermal.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3368-thermal.dtsi
@@ -96,7 +96,7 @@ gpu_thermal: gpu_thermal {
 			type = "passive";
 		};
 		gpu_crit: gpu_crit {
-			temperature = <1150000>; /* millicelsius */
+			temperature = <115000>; /* millicelsius */
 			hysteresis = <2000>; /* millicelsius */
 			type = "critical";
 		};


### PR DESCRIPTION
there is a typo in gpu thermal crit temperature, 1150°C instead of 115°C